### PR TITLE
feat: add __version__ and --version flag

### DIFF
--- a/SetMusicParentalRating/README.md
+++ b/SetMusicParentalRating/README.md
@@ -69,6 +69,7 @@ Positional:
   library_path              Library root (overrides config)
 
 Options:
+  --version                 Show program version and exit
   --config PATH             TOML config file (default: explicit_config.toml in script dir)
   --env-file PATH           .env file to load (default: .env in repo root; e.g. --env-file .env.prod)
   --server-type TYPE        'emby', 'jellyfin', or 'both' — auto-detected from configured

--- a/SetMusicParentalRating/SetMusicParentalRating.py
+++ b/SetMusicParentalRating/SetMusicParentalRating.py
@@ -8,6 +8,8 @@ On older Python, falls back to the tomli package.
 
 from __future__ import annotations
 
+__version__ = "1.0.0"
+
 import argparse
 import csv
 import json
@@ -1335,6 +1337,9 @@ def build_parser() -> argparse.ArgumentParser:
         prog="SetMusicParentalRating",
         description="Scan sidecar lyric files for explicit content and set "
         "OfficialRating on matching tracks via the Emby or Jellyfin API.",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
     )
     parser.add_argument(
         "library_path",


### PR DESCRIPTION
## Summary
- Add `__version__ = "1.0.0"` module-level constant
- Add `--version` CLI flag via `argparse`'s `action="version"`
- Document `--version` in README CLI Reference

## Test plan
- [x] `--version` outputs `SetMusicParentalRating 1.0.0`
- [x] `__version__` importable: `from SetMusicParentalRating import SetMusicParentalRating; print(SetMusicParentalRating.__version__)`
- [x] `ruff check` + `ruff format --check` pass
- [x] `pre-commit run --all-files` passes

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` command-line flag to display the application version.
  * Updated documentation to reflect the new version option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->