### PR TITLE
chore: audit thread-safety docs, Config comments, _path_parts cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,11 @@ pre-commit run --all-files
 - Item updates require the full item body: `POST /Items/{id}` with the complete JSON from the GET
 - Genre listing: `GET /MusicGenres?Recursive=true` (used by `--list-genres`)
 
+### Thread safety
+The script is single-threaded. `process_library` uses shared mutable state
+(`handled_paths: set`, `results: list`) that is not thread-safe. If parallelism
+is ever added, these would need locking or per-thread accumulation.
+
 ### Configuration
 - Secrets (API key, URL) go in `.env` at the repo root — never in TOML or committed files
 - Use `--env-file .env.prod` to target the production server

--- a/SetMusicParentalRating/SetMusicParentalRating.py
+++ b/SetMusicParentalRating/SetMusicParentalRating.py
@@ -117,8 +117,8 @@ class MediaServerError(Exception):
 @dataclass
 class Config:
     library_path: Path
-    server_url: str
-    server_api_key: str
+    server_url: str  # "" in "both" mode; use emby_url/jellyfin_url instead
+    server_api_key: str  # "" in "both" mode; use emby_api_key/jellyfin_api_key instead
     server_type: str = "emby"
     r_stems: list[str] = field(default_factory=lambda: list(DEFAULT_R_STEMS))
     r_exact: list[str] = field(default_factory=lambda: list(DEFAULT_R_EXACT))
@@ -848,9 +848,7 @@ def _normalize_path(p: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _path_parts(
-    audio_path: Path | None, library_path: Path | None = None
-) -> tuple[str, str]:
+def _path_parts(audio_path: Path | None, library_path: Path | None) -> tuple[str, str]:
     """Best-effort fallback using the path relative to the library root."""
     if audio_path is None:
         return "", ""
@@ -925,7 +923,13 @@ def write_report(
 
 
 def process_library(config: Config) -> list[DetectionResult]:
-    """Main flow: scan sidecars -> detect -> update media server."""
+    """Main flow: scan sidecars -> detect -> update media server.
+
+    Thread-safety: this function is single-threaded by design. The shared
+    ``handled_paths`` set and ``results`` list are not thread-safe. If
+    parallelism is added (e.g. concurrent Jellyfin lyrics fetches), these
+    would need locking or per-thread accumulation.
+    """
     lp = config.library_path
     if not lp.is_absolute():
         log.error("library_path must be an absolute path; got %r", str(lp))


### PR DESCRIPTION
## Summary
- Document thread-safety assumptions on `process_library()` (single-threaded, shared mutable `handled_paths`/`results`)
- Add inline comments on `Config.server_url` / `Config.server_api_key` clarifying "both" mode semantics
- Remove `= None` default from `_path_parts(library_path)` — callers already pass it explicitly
- Add `### Thread safety` subsection to `CLAUDE.md` architecture docs
- Confirmed no unused imports/variables (`ruff check --select F401,F841`)

## Test plan
- [x] `import SetMusicParentalRating` succeeds
- [x] `ruff check` + `ruff format --check` pass
- [x] `ruff check --select F401,F841` — clean
- [x] `pre-commit run --all-files` passes
- [x] UAT dry-run against Emby — no behavioral changes (CSV identical to main)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added thread-safety guidance describing single-threaded behavior and shared-state considerations if parallelism is introduced.
  * Clarified configuration behavior for the "both" mode in inline config documentation so users understand how that setting behaves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->