### PR TITLE
feat: replace filesystem scan with API-driven lyrics pass (#34)

### DIFF
--- a/SetMusicParentalRating/SetMusicParentalRating.py
+++ b/SetMusicParentalRating/SetMusicParentalRating.py
@@ -1139,6 +1139,7 @@ def process_library(config: Config) -> list[DetectionResult]:
     for norm_path, item in items_in_scope.items():
         item_id, prev_rating, artist, album = _item_fields(item)
         if not item_id:
+            log.warning("Server item at %s has no 'Id'; skipping", norm_path)
             continue
 
         # Try lyrics


### PR DESCRIPTION
## Summary

- Rewrite `process_library()` to use API-driven lyrics fetching instead of filesystem scanning
- Three-pass architecture (sidecar → embedded → genre) collapsed into a single pass: `fetch_lyrics()` → classify → genre fallback
- Net -145 lines (63 added, 208 removed)
- `DetectionResult.source` now `"lyrics"` instead of `"sidecar"`/`"embedded"` for lyrics-based results
- `force_rate_library()`, `scan_library()`, and other filesystem functions left intact for removal in #35/#36

Closes #34

## Test plan

- [x] UAT Emby (dry-run): 808 lyrics evaluated, 4 R-rated, 2 PG-13, 802 clean, 0 errors
- [x] UAT Jellyfin (dry-run): 798 lyrics evaluated, 4 R-rated, 2 PG-13, 792 clean, 0 errors
- [x] CSV reports generated with correct columns and `source="lyrics"`
- [x] ruff check/format pass
- [x] Import smoke test pass

**Stacked on:** #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added genre-based rating detection as fallback when lyrics are unavailable

* **Improvements**
  * Streamlined and unified music rating processing workflow
  * Enhanced reporting to clearly identify detection sources (lyrics or genre)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->