### PR TITLE
docs: add security policy and enable vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,8 @@ When reporting, please include:
 
 This project interacts with Emby and Jellyfin media server APIs using API keys. Security concerns include:
 
-- API key exposure (keys should only be in `.env` files, never committed)
+- API key exposure (keys should only be in `.env` files or environment variables, never committed to source control)
 - Server-side request forgery (SSRF) via user-supplied server URLs
-- Command injection via config values
 
 ## Security Measures
 


### PR DESCRIPTION
## Summary

- Add SECURITY.md with vulnerability reporting instructions and scope
- Enable Dependabot vulnerability alerts, automated security fixes, and private vulnerability reporting (already applied via API)

## Test plan

- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published a project security policy documenting supported versions, vulnerability reporting via private advisories with a 72-hour response commitment, scope notes (including API key and user-supplied URL risks), and recommended security measures (no real credentials in example files, env-var usage, Dependabot alerts, and CodeQL scans).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->