### PR TITLE
fix: centralize config path resolution and add force-tree viewporting

### DIFF
--- a/smpr/src/main.rs
+++ b/smpr/src/main.rs
@@ -308,30 +308,12 @@ fn main() {
             env_file,
             verbose: v,
         } => {
-            let config_dir = wizard::resolve_config_dir(config.as_deref());
-            let config_filename = if let Some(cfg) = &config {
-                let p = PathBuf::from(cfg);
-                if p.is_dir() {
-                    eprintln!(
-                        "Error: --config must be a file path, not a directory: {}",
-                        p.display()
-                    );
-                    process::exit(1);
-                }
-                p.file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| "config.toml".to_string())
-            } else if config_dir == std::env::current_dir().unwrap_or_default() {
-                "explicit_config.toml".to_string()
-            } else {
-                "config.toml".to_string()
-            };
-            let config_path = config_dir.join(&config_filename);
-
-            let env_path = match &env_file {
-                Some(p) => PathBuf::from(p),
-                None => config_dir.join(".env"),
-            };
+            let (config_path, env_path) =
+                wizard::resolve_config_paths(config.as_deref(), env_file.as_deref())
+                    .unwrap_or_else(|e| {
+                        eprintln!("Error: {e}");
+                        process::exit(1);
+                    });
 
             // Try to load existing config
             let existing = if config_path.is_file() {

--- a/smpr/src/tui/app.rs
+++ b/smpr/src/tui/app.rs
@@ -139,6 +139,7 @@ pub struct ForceTreeState {
     pub cursor: usize,
     pub radio_cursor: usize,
     pub expanded: std::collections::HashSet<usize>,
+    pub scroll_offset: usize,
 }
 
 pub const RATING_OPTIONS: [Option<&str>; 4] = [None, Some("G"), Some("PG-13"), Some("R")];

--- a/smpr/src/tui/app.rs
+++ b/smpr/src/tui/app.rs
@@ -140,6 +140,8 @@ pub struct ForceTreeState {
     pub radio_cursor: usize,
     pub expanded: std::collections::HashSet<usize>,
     pub scroll_offset: usize,
+    /// Last rendered pane height (set by render, used by scroll adjustment).
+    pub view_height: usize,
 }
 
 pub const RATING_OPTIONS: [Option<&str>; 4] = [None, Some("G"), Some("PG-13"), Some("R")];

--- a/smpr/src/tui/mod.rs
+++ b/smpr/src/tui/mod.rs
@@ -242,6 +242,7 @@ fn handle_action(state: &mut app::AppState, action: keymap::Action) {
                 }
                 if next < len {
                     state.force_state.cursor = next;
+                    adjust_force_scroll(state);
                 }
             }
         }
@@ -295,6 +296,7 @@ fn handle_action(state: &mut app::AppState, action: keymap::Action) {
                 }
                 if !state.force_state.nodes.is_empty() && state.force_state.nodes[prev].depth > 0 {
                     state.force_state.cursor = prev;
+                    adjust_force_scroll(state);
                 }
             }
         }
@@ -668,6 +670,29 @@ fn load_field_into_input(state: &mut AppState, label: &str) {
         None => String::new(),
     };
     state.server_state.text_input.set(&text);
+}
+
+/// Adjust scroll_offset so the cursor stays visible in the force-rate tree.
+/// Assumes a visible height of ~20 rows (will be clamped by actual render).
+fn adjust_force_scroll(state: &mut AppState) {
+    // Count visible position of cursor
+    let mut visible_pos: usize = 0;
+    for (i, _node) in state.force_state.nodes.iter().enumerate() {
+        if !widgets::force_tree::is_node_visible(&state.force_state, i) {
+            continue;
+        }
+        if i == state.force_state.cursor {
+            break;
+        }
+        visible_pos += 1;
+    }
+
+    let page_size = 15; // approximate visible rows
+    if visible_pos < state.force_state.scroll_offset {
+        state.force_state.scroll_offset = visible_pos;
+    } else if visible_pos >= state.force_state.scroll_offset + page_size {
+        state.force_state.scroll_offset = visible_pos - page_size + 1;
+    }
 }
 
 fn save(state: &mut AppState) -> Result<(), TuiError> {

--- a/smpr/src/tui/mod.rs
+++ b/smpr/src/tui/mod.rs
@@ -90,6 +90,10 @@ pub fn run_editor(
     let mut terminal = Terminal::new(backend)?;
 
     loop {
+        // Update view_height from terminal size (minus title, status, borders = 4 rows)
+        let term_height = terminal.size()?.height as usize;
+        state.force_state.view_height = term_height.saturating_sub(4);
+
         terminal.draw(|frame| render::render(frame, &state))?;
 
         let evt = event::poll_event(std::time::Duration::from_millis(100))?;
@@ -348,6 +352,7 @@ fn handle_action(state: &mut app::AppState, action: keymap::Action) {
                     } else {
                         state.force_state.expanded.insert(cursor);
                     }
+                    adjust_force_scroll(state);
                 }
             }
         },
@@ -673,21 +678,37 @@ fn load_field_into_input(state: &mut AppState, label: &str) {
 }
 
 /// Adjust scroll_offset so the cursor stays visible in the force-rate tree.
-/// Assumes a visible height of ~20 rows (will be clamped by actual render).
+/// Uses `view_height` stored from the last terminal size query.
 fn adjust_force_scroll(state: &mut AppState) {
-    // Count visible position of cursor
+    // Count total visible nodes and cursor's position among them
     let mut visible_pos: usize = 0;
+    let mut total_visible: usize = 0;
+    let mut found_cursor = false;
     for (i, _node) in state.force_state.nodes.iter().enumerate() {
         if !widgets::force_tree::is_node_visible(&state.force_state, i) {
             continue;
         }
-        if i == state.force_state.cursor {
-            break;
+        if i == state.force_state.cursor && !found_cursor {
+            found_cursor = true;
+            visible_pos = total_visible;
         }
-        visible_pos += 1;
+        total_visible += 1;
     }
 
-    let page_size = 15; // approximate visible rows
+    // Use stored view_height, or fall back to a conservative default
+    let page_size = if state.force_state.view_height > 0 {
+        state.force_state.view_height
+    } else {
+        15
+    };
+
+    // Clamp scroll_offset to valid range
+    let max_scroll = total_visible.saturating_sub(page_size);
+    if state.force_state.scroll_offset > max_scroll {
+        state.force_state.scroll_offset = max_scroll;
+    }
+
+    // Ensure cursor is within the visible window
     if visible_pos < state.force_state.scroll_offset {
         state.force_state.scroll_offset = visible_pos;
     } else if visible_pos >= state.force_state.scroll_offset + page_size {

--- a/smpr/src/tui/widgets/force_tree.rs
+++ b/smpr/src/tui/widgets/force_tree.rs
@@ -73,6 +73,7 @@ pub fn init_force_state(state: &mut AppState) {
         cursor: initial_cursor,
         radio_cursor: 0,
         expanded,
+        scroll_offset: 0,
     };
 
     // Set radio_cursor to match current rating of cursor node
@@ -231,6 +232,7 @@ pub fn render_force_tree(state: &AppState, area: Rect, buf: &mut Buffer) {
     }
 
     let mut y = inner.y;
+    let mut visible_idx: usize = 0;
 
     for (i, node) in state.force_state.nodes.iter().enumerate() {
         if y >= inner.y + inner.height {
@@ -240,6 +242,13 @@ pub fn render_force_tree(state: &AppState, area: Rect, buf: &mut Buffer) {
         if !is_node_visible(&state.force_state, i) {
             continue;
         }
+
+        // Skip nodes before scroll offset
+        if visible_idx < state.force_state.scroll_offset {
+            visible_idx += 1;
+            continue;
+        }
+        visible_idx += 1;
 
         let is_cursor = i == state.force_state.cursor;
         let indent = "  ".repeat(node.depth);

--- a/smpr/src/tui/widgets/force_tree.rs
+++ b/smpr/src/tui/widgets/force_tree.rs
@@ -74,6 +74,7 @@ pub fn init_force_state(state: &mut AppState) {
         radio_cursor: 0,
         expanded,
         scroll_offset: 0,
+        view_height: 0,
     };
 
     // Set radio_cursor to match current rating of cursor node

--- a/smpr/src/wizard/mod.rs
+++ b/smpr/src/wizard/mod.rs
@@ -64,6 +64,47 @@ fn from_inquire(e: inquire::InquireError) -> WizardError {
     }
 }
 
+/// Resolve the full config file path and .env path from CLI arguments.
+///
+/// Validates that --config is not a directory. Returns (config_path, env_path).
+pub fn resolve_config_paths(
+    cli_config: Option<&str>,
+    cli_env_file: Option<&str>,
+) -> Result<(PathBuf, PathBuf), WizardError> {
+    let config_dir = resolve_config_dir(cli_config);
+
+    let config_filename = if let Some(cfg) = cli_config {
+        let cfg_path = PathBuf::from(cfg);
+        if cfg_path.is_dir() {
+            return Err(WizardError::Prompt(format!(
+                "--config must be a file path, not a directory: {}",
+                cfg_path.display()
+            )));
+        }
+        match cfg_path.file_name() {
+            Some(name) => name.to_string_lossy().to_string(),
+            None => {
+                return Err(WizardError::Prompt(format!(
+                    "invalid --config path (expected a file path): {}",
+                    cfg_path.display()
+                )));
+            }
+        }
+    } else if config_dir == std::env::current_dir().unwrap_or_default() {
+        "explicit_config.toml".to_string()
+    } else {
+        "config.toml".to_string()
+    };
+
+    let config_path = config_dir.join(&config_filename);
+    let env_path = match cli_env_file {
+        Some(p) => PathBuf::from(p),
+        None => config_dir.join(".env"),
+    };
+
+    Ok((config_path, env_path))
+}
+
 /// Resolve the config directory for reading/writing.
 ///
 /// Priority:
@@ -104,36 +145,7 @@ pub fn run_wizard(
     verbose: bool,
     add_server: bool,
 ) -> Result<(), WizardError> {
-    let config_dir = resolve_config_dir(cli_config);
-    let config_filename = if let Some(cfg) = cli_config {
-        let cfg_path = PathBuf::from(cfg);
-        // Reject directories
-        if cfg_path.is_dir() {
-            return Err(WizardError::Prompt(format!(
-                "--config must be a file path, not a directory: {}",
-                cfg_path.display()
-            )));
-        }
-        match cfg_path.file_name() {
-            Some(name) => name.to_string_lossy().to_string(),
-            None => {
-                return Err(WizardError::Prompt(format!(
-                    "invalid --config path (expected a file path): {}",
-                    cfg_path.display()
-                )));
-            }
-        }
-    } else if config_dir == std::env::current_dir().unwrap_or_default() {
-        "explicit_config.toml".to_string()
-    } else {
-        "config.toml".to_string()
-    };
-    let config_path = config_dir.join(&config_filename);
-
-    let env_path = match cli_env_file {
-        Some(p) => PathBuf::from(p), // CLI-provided path: relative to CWD (like other subcommands)
-        None => config_dir.join(".env"), // Default: alongside config file
-    };
+    let (config_path, env_path) = resolve_config_paths(cli_config, cli_env_file)?;
 
     // Step 0: Detect existing config
     let existing = if config_path.is_file() {


### PR DESCRIPTION
## Summary

- Extract `resolve_config_paths()` in `wizard/mod.rs` that combines directory resolution, filename extraction, directory rejection, and env path derivation into a single shared function. Both `main.rs` Configure branch and `run_wizard` now call it, eliminating duplicated path logic. (#122)
- Add `scroll_offset` to `ForceTreeState` for viewport support. The force-rate tree render skips nodes before the scroll offset, and cursor movement automatically adjusts scroll to keep the cursor visible. (#123)

Closes #122, #123

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 210 tests pass
- [x] Existing wizard path resolution tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling in the force-rating tree so the selected item stays visible as you navigate and expand/collapse nodes.
  * Render performance optimized by skipping off-screen items during tree drawing.

* **Refactor**
  * Centralized configuration and environment path resolution for more consistent detection and clearer error reporting when inputs are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->