### PR TITLE
feat: add markdownlint to pre-commit hooks

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,8 @@
+{
+  "ignores": [
+    ".venv/**",
+    "smpr/target/**",
+    "docs/superpowers/**",
+    "node_modules/**"
+  ]
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "MD013": false,
+  "MD024": false,
+  "MD041": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.21.0
+    hooks:
+      - id: markdownlint-cli2
+        args: []
+
   - repo: local
     hooks:
       - id: cargo-fmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ Key types: `RawConfig` (serde TOML shape) vs `Config` (resolved, validated). `Cl
 Auth headers: `X-Emby-Token` (Emby) or `X-MediaBrowser-Token` (Jellyfin).
 
 Server type detection (`detect_server_type`): `GET /System/Info/Public` (unauthenticated). Three-tier detection:
+
 1. `ProductName == "Jellyfin Server"` → Jellyfin; any other ProductName → Emby
 2. Structural: `LocalAddress` (singular) → Jellyfin; `LocalAddresses` (plural) → Emby
 3. `Server` header: "Kestrel" → Jellyfin; other → Emby
@@ -118,6 +119,7 @@ Lyrics fetch (Emby): external subtitle streams via `GET /Videos/{id}/{msid}/Subt
 `DetectionEngine` is constructed from `DetectionConfig`, pre-lowercasing stems and compiling exact-match regexes.
 
 `classify_lyrics(text)` returns `(Option<tier>, Vec<matched_words>)`:
+
 1. Tokenize lowercased text with `[a-z']+` regex
 2. **R tier first**: `detect_stems` (substring match with false-positive filter) + `detect_exact` (word-boundary regex `\b{word}\b`)
 3. **PG-13 tier**: same approach, only checked if R tier found nothing
@@ -143,6 +145,7 @@ All three workflows follow the same pattern: resolve library scope → prefetch 
 ### Configure wizard (wizard/)
 
 `run_wizard` drives a multi-step interactive flow using `inquire` prompts:
+
 1. Detect existing config; offer to add a server if one exists
 2. `server.rs` — prompt for server URL, validate connectivity, auto-detect type
 3. `auth.rs` — prompt for API key directly or authenticate via username/password

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CLI tool for [Emby](https://emby.media/) and [Jellyfin](https://jellyfin.org/) m
 Pre-built binaries are available on [GitHub Releases](https://github.com/sydlexius/media-automation/releases):
 
 | Platform | Binary |
-|----------|--------|
+| -------- | ------ |
 | Linux (x86_64, static) | `smpr-linux-x86_64` |
 | macOS (Intel) | `smpr-macos-intel` |
 | macOS (Apple Silicon) | `smpr-macos-apple-silicon` |


### PR DESCRIPTION
## Summary

- Add `markdownlint-cli2` hook to `.pre-commit-config.yaml`
- Add `.markdownlint.json` disabling MD013 (line length), MD024 (duplicate headings), MD041 (first-line heading)
- Add `.markdownlint-cli2.jsonc` excluding `.venv/`, `smpr/target/`, `docs/superpowers/`
- Fix existing violations: MD032 (blank lines around lists) in CLAUDE.md, MD060 (table style) in README.md

Closes #120

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` — 0 errors on all 6 tracked markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Markdown linting configuration files to the repository.
  * Added pre-commit hook for automated Markdown linting.

* **Documentation**
  * Updated documentation formatting in README and supporting files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->