### PR TITLE
docs: restructure READMEs with root overview and user-facing smpr guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,21 @@
-# smpr — Set Music Parental Rating
+# media-automation
 
-CLI tool for [Emby](https://emby.media/) and [Jellyfin](https://jellyfin.org/) media servers. Fetches lyrics, detects explicit content using tiered word detection (R / PG-13), and sets parental ratings on audio tracks.
+Automation tools for home media servers.
 
-## Installation
+## Tools
 
-### Download
+### [smpr](smpr/) — Set Music Parental Rating
 
-Pre-built binaries are available on [GitHub Releases](https://github.com/sydlexius/media-automation/releases):
+Automatically rate music tracks on [Emby](https://emby.media/) and
+[Jellyfin](https://jellyfin.org/) servers based on lyrics content. Fetches
+lyrics from your server, detects explicit language using tiered word detection
+(R / PG-13 / G), and sets `OfficialRating` on each track.
 
-| Platform | Binary |
-| -------- | ------ |
-| Linux (x86_64, static) | `smpr-linux-x86_64` |
-| macOS (Intel) | `smpr-macos-intel` |
-| macOS (Apple Silicon) | `smpr-macos-apple-silicon` |
-| Windows (x86_64) | `smpr-windows-x86_64.exe` |
+- Interactive setup wizard and TUI config editor
+- Multi-server support (Emby and Jellyfin simultaneously)
+- Per-library and per-location force-rating overrides
+- Customizable detection word lists and genre allow-lists
+- CSV reporting and dry-run mode
+- Cross-platform: Linux, macOS, Windows
 
-### Build from source
-
-```bash
-cd smpr
-cargo build --release
-# Binary at: target/release/smpr
-```
-
-## Quick Start
-
-```bash
-# Interactive setup wizard — creates config + .env
-smpr configure
-
-# Analyze a library without making changes
-smpr rate --library Music --dry-run
-
-# Set ratings based on lyrics analysis
-smpr rate --library Music
-
-# Force-rate a known-clean library
-smpr force G --library "Classical Music"
-
-# Remove all ratings from a library
-smpr reset --library Music
-
-# Generate a CSV report
-smpr rate --library Music --dry-run --report report.csv
-```
-
-For full options: `smpr --help` or `smpr <subcommand> --help`.
-
-## Configuration
-
-Run `smpr configure` for an interactive setup wizard — recommended for first-time users. It will create `explicit_config.toml` and a `.env` file with your API keys.
-
-For manual setup:
-
-- **Config file**: `explicit_config.toml` in the current directory, or the platform config directory (e.g., `~/.config/smpr/config.toml` on Linux, `~/Library/Application Support/smpr/config.toml` on macOS)
-- **API keys**: stored in `.env` as `{LABEL}_API_KEY` (e.g., `HOME_EMBY_API_KEY` for a server named `home-emby`)
-- **Precedence**: CLI flags > env vars > `.env` file > TOML config > defaults
-
-Example config structure:
-
-```toml
-[servers.home-emby]
-url = "http://192.168.1.126:8096"
-# type = "emby"  # optional; auto-detected if omitted
-
-[servers.home-emby.libraries.Music]
-# force_rating = "G"  # optional; force all tracks in this library to G
-```
-
-```bash
-# .env
-HOME_EMBY_API_KEY=your-api-key-here
-```
-
-API keys never go in the TOML file — only in `.env`.
-
-## Development
-
-```bash
-cd smpr
-cargo test --verbose -- --test-threads=1   # tests must run sequentially
-cargo fmt -- --check && cargo clippy -- -D warnings
-cargo build --release
-```
+Pre-built binaries on [GitHub Releases](https://github.com/sydlexius/media-automation/releases).

--- a/smpr/README.md
+++ b/smpr/README.md
@@ -1,0 +1,153 @@
+# smpr — Set Music Parental Rating
+
+Automatically rate music tracks on your Emby or Jellyfin server. Fetches lyrics,
+detects explicit content, and sets parental ratings (R / PG-13 / G) so you can
+filter what plays on shared devices.
+
+## Installation
+
+### Download
+
+Pre-built binaries are available on
+[GitHub Releases](https://github.com/sydlexius/media-automation/releases):
+
+| Platform | Binary |
+| -------- | ------ |
+| Linux (x86_64, static) | `smpr-linux-x86_64` |
+| macOS (Intel) | `smpr-macos-intel` |
+| macOS (Apple Silicon) | `smpr-macos-apple-silicon` |
+| Windows (x86_64) | `smpr-windows-x86_64.exe` |
+
+### Build from source
+
+```bash
+cd smpr
+cargo build --release
+# Binary at: target/release/smpr
+```
+
+## Getting Started
+
+### First-time setup
+
+Run the interactive wizard to connect to your server and create a config file:
+
+```bash
+smpr configure
+```
+
+The wizard walks you through:
+
+1. Server URL and authentication
+2. Music library discovery
+3. Genre allow-list selection (genres auto-rated G)
+4. Detection word list review
+5. Update behavior preferences
+
+It creates a TOML config file and a `.env` file with your API key.
+
+### Rating your library
+
+```bash
+# Preview what would change (no modifications)
+smpr rate --library Music --dry-run
+
+# Apply ratings based on lyrics analysis
+smpr rate --library Music
+
+# Generate a CSV report of all decisions
+smpr rate --library Music --report report.csv
+```
+
+### Other commands
+
+```bash
+# Force-rate an entire library (no lyrics check)
+smpr force G --library "Kids Music"
+
+# Remove all ratings from a library
+smpr reset --library Music
+```
+
+For full options: `smpr --help` or `smpr rate --help`.
+
+## Editing Your Config
+
+If you already have a config file, `smpr configure` opens a TUI editor where
+you can modify all settings:
+
+- **Servers** — edit URL, API key, server type; scan for libraries (`r` key)
+- **G-Rated Genres** — pick genres that get auto-rated G (fetches from server)
+- **Force Ratings** — set per-library or per-location rating overrides
+  (`n`/`g`/`p`/`r` keys)
+- **Detection Rules** — view and edit the word lists used for content detection
+- **Preferences** — toggle whether already-rated tracks get re-evaluated
+
+Press `s` to save, `q` to quit.
+
+## Configuration
+
+### Config file locations
+
+smpr looks for config in this order:
+
+1. `--config <path>` flag (explicit path)
+2. `explicit_config.toml` in the current directory
+3. Platform config directory:
+   - Linux: `~/.config/smpr/config.toml`
+   - macOS: `~/Library/Application Support/smpr/config.toml`
+   - Windows: `%APPDATA%\smpr\config.toml`
+
+### API keys
+
+API keys are stored in a `.env` file alongside your config (never in the TOML):
+
+```bash
+HOME_EMBY_API_KEY=your-api-key-here
+```
+
+The variable name is derived from the server label: `home-emby` becomes
+`HOME_EMBY_API_KEY` (uppercase, hyphens to underscores).
+
+### Example config
+
+```toml
+[servers.home-emby]
+url = "http://192.168.1.126:8096"
+# type = "emby"  # optional; auto-detected
+
+[servers.home-emby.libraries.Music]
+# force_rating = "G"  # force all tracks in this library to G
+
+[servers.home-emby.libraries.Music.locations.Classical]
+force_rating = "G"  # force tracks in this location to G
+
+[detection.g_genres]
+genres = ["Ambient", "Classical", "Instrumental", "Piano"]
+
+[general]
+overwrite = false  # skip tracks that already have a rating
+```
+
+### Multi-server
+
+You can configure multiple servers. Use `--server <name>` to target specific
+ones, or omit it to process all:
+
+```bash
+smpr rate --server home-emby --library Music
+```
+
+## How It Works
+
+1. **Fetch** — retrieves lyrics for each audio track from your server
+2. **Detect** — scans lyrics for explicit words using two tiers:
+   - **R**: strong profanity (stem + exact matching)
+   - **PG-13**: moderate profanity (only checked if no R-tier match)
+3. **Genre fallback** — tracks with no lyrics get rated G if their genre is in
+   the allow-list (e.g., Classical, Instrumental)
+4. **Apply** — sets `OfficialRating` on the track via the server API
+5. **Report** — optionally writes a CSV with every decision made
+
+False positives are handled by a configurable ignore list (e.g., "cocktail",
+"hancock", "documentary" won't trigger on "cock" or "cum" stems).


### PR DESCRIPTION
## Summary

- **Root `README.md`**: elevator-pitch overview of the repo with a link to each tool
- **`smpr/README.md`**: user-facing guide covering installation, setup wizard, rating commands, TUI config editor, configuration reference, multi-server setup, and how detection works

The old root README was a developer-oriented smpr reference. Now the root is a brief directory, and each tool gets its own user-focused README.

## Test plan

- [x] Links resolve correctly
- [x] Content is user-oriented (no internal architecture details)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive user guide for the smpr tool: installation, interactive setup, rating workflows, configuration, API key handling, commands and examples.
  * Updated main project README: rebranded to "media-automation", simplified overview and "Tools" section, replaced detailed setup/usage with a concise note about pre-built release binaries and a high-level feature summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->